### PR TITLE
feat: cc-m CLI client + safe self-hosting

### DIFF
--- a/v1/package.json
+++ b/v1/package.json
@@ -4,7 +4,8 @@
   "description": "Multi-agent orchestrator for Claude Code",
   "type": "module",
   "bin": {
-    "cc-manager": "dist/index.js"
+    "cc-manager": "dist/index.js",
+    "cc-m": "dist/cli.js"
   },
   "keywords": [
     "claude",

--- a/v1/src/agent-runner.ts
+++ b/v1/src/agent-runner.ts
@@ -275,6 +275,7 @@ export class AgentRunner {
         "-p",
         "--dangerously-skip-permissions",
         "--output-format", "stream-json",
+        "--verbose",
         "--model", this.model,
       ];
       if (task.maxBudget > 0) {

--- a/v1/src/cli.ts
+++ b/v1/src/cli.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { readFileSync } from "fs";
+
+const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+const BASE_URL = process.env.CC_MANAGER_URL ?? "http://localhost:8080";
+
+// ── Helpers ──
+
+async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init?.headers },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`${res.status} ${res.statusText}: ${body}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function out(data: unknown, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  if (Array.isArray(data)) {
+    for (const item of data) printRow(item);
+  } else if (data && typeof data === "object") {
+    printRow(data as Record<string, unknown>);
+  } else {
+    console.log(data);
+  }
+}
+
+function printRow(obj: Record<string, unknown>): void {
+  const id = obj.id ?? "";
+  const status = obj.status ?? "";
+  const prompt = String(obj.prompt ?? "").slice(0, 80).replace(/\n/g, " ");
+  const cost = obj.costUsd != null ? `$${Number(obj.costUsd).toFixed(2)}` : "";
+  const duration = obj.durationMs != null ? `${(Number(obj.durationMs) / 1000).toFixed(1)}s` : "";
+  console.log(`${String(id).padEnd(10)} ${String(status).padEnd(10)} ${cost.padEnd(8)} ${duration.padEnd(8)} ${prompt}`);
+}
+
+function statusColor(s: string): string {
+  const colors: Record<string, string> = {
+    pending: "\x1b[33m",   // yellow
+    running: "\x1b[36m",   // cyan
+    success: "\x1b[32m",   // green
+    failed: "\x1b[31m",    // red
+    timeout: "\x1b[35m",   // magenta
+    cancelled: "\x1b[90m", // gray
+  };
+  return `${colors[s] ?? ""}${s}\x1b[0m`;
+}
+
+function printTask(t: Record<string, unknown>): void {
+  const col = 16;
+  console.log(`  ${"ID".padEnd(col)}${t.id}`);
+  console.log(`  ${"Status".padEnd(col)}${statusColor(String(t.status))}`);
+  console.log(`  ${"Prompt".padEnd(col)}${String(t.prompt ?? "").slice(0, 120)}`);
+  if (t.agent) console.log(`  ${"Agent".padEnd(col)}${t.agent}`);
+  if (t.priority && t.priority !== "normal") console.log(`  ${"Priority".padEnd(col)}${t.priority}`);
+  if (t.costUsd) console.log(`  ${"Cost".padEnd(col)}$${Number(t.costUsd).toFixed(4)}`);
+  if (t.durationMs) console.log(`  ${"Duration".padEnd(col)}${(Number(t.durationMs) / 1000).toFixed(1)}s`);
+  if (t.tokenInput) console.log(`  ${"Tokens".padEnd(col)}${t.tokenInput} in / ${t.tokenOutput} out`);
+  if (t.worktree) console.log(`  ${"Worker".padEnd(col)}${t.worktree}`);
+  if (t.error) console.log(`  ${"Error".padEnd(col)}\x1b[31m${String(t.error).slice(0, 200)}\x1b[0m`);
+  if (t.output) console.log(`  ${"Output".padEnd(col)}${String(t.output).slice(0, 300)}`);
+  if (t.tags) console.log(`  ${"Tags".padEnd(col)}${(t.tags as string[]).join(", ")}`);
+  console.log("");
+}
+
+// ── CLI ──
+
+const program = new Command()
+  .name("cc-m")
+  .description("CLI client for cc-manager")
+  .version(version)
+  .option("--url <url>", "cc-manager server URL", BASE_URL)
+  .option("--json", "Output raw JSON");
+
+// ── submit ──
+program
+  .command("submit <prompt>")
+  .description("Submit a task")
+  .option("-t, --timeout <s>", "Timeout in seconds")
+  .option("-b, --budget <usd>", "Max budget per task")
+  .option("-p, --priority <level>", "Priority: urgent|high|normal|low")
+  .option("-a, --agent <cmd>", "Agent: claude|claude-sdk|codex|<any cli>")
+  .option("--tags <tags>", "Comma-separated tags")
+  .action(async (prompt: string, opts: Record<string, string>) => {
+    const body: Record<string, unknown> = { prompt };
+    if (opts.timeout) body.timeout = Number(opts.timeout);
+    if (opts.budget) body.maxBudget = Number(opts.budget);
+    if (opts.priority) body.priority = opts.priority;
+    if (opts.agent) body.agent = opts.agent;
+    if (opts.tags) body.tags = opts.tags.split(",").map((t: string) => t.trim());
+    const result = await api("/api/tasks", { method: "POST", body: JSON.stringify(body) });
+    out(result, !!program.opts().json);
+  });
+
+// ── batch ──
+program
+  .command("batch <prompts...>")
+  .description("Submit multiple tasks")
+  .option("-t, --timeout <s>", "Timeout in seconds")
+  .option("-b, --budget <usd>", "Max budget per task")
+  .action(async (prompts: string[], opts: Record<string, string>) => {
+    const body: Record<string, unknown> = { prompts };
+    if (opts.timeout) body.timeout = Number(opts.timeout);
+    if (opts.budget) body.maxBudget = Number(opts.budget);
+    const result = await api("/api/tasks/batch", { method: "POST", body: JSON.stringify(body) });
+    out(result, !!program.opts().json);
+  });
+
+// ── list ──
+program
+  .command("list")
+  .alias("ls")
+  .description("List tasks")
+  .option("-s, --status <status>", "Filter by status")
+  .option("-n, --limit <n>", "Max results", "20")
+  .option("--tag <tag>", "Filter by tag")
+  .action(async (opts: Record<string, string>) => {
+    const params = new URLSearchParams();
+    if (opts.status) params.set("status", opts.status);
+    if (opts.limit) params.set("limit", opts.limit);
+    if (opts.tag) params.set("tag", opts.tag);
+    const tasks = await api<Array<Record<string, unknown>>>(`/api/tasks?${params}`);
+    if (program.opts().json) {
+      console.log(JSON.stringify(tasks, null, 2));
+    } else {
+      console.log(`${"ID".padEnd(10)} ${"STATUS".padEnd(10)} ${"COST".padEnd(8)} ${"TIME".padEnd(8)} PROMPT`);
+      console.log("─".repeat(80));
+      for (const t of tasks) printRow(t);
+      console.log(`\n${tasks.length} tasks`);
+    }
+  });
+
+// ── status (single task) ──
+program
+  .command("status <id>")
+  .alias("get")
+  .description("Get task details")
+  .action(async (id: string) => {
+    const task = await api<Record<string, unknown>>(`/api/tasks/${id}`);
+    if (program.opts().json) {
+      console.log(JSON.stringify(task, null, 2));
+    } else {
+      printTask(task);
+    }
+  });
+
+// ── logs (task output) ──
+program
+  .command("logs <id>")
+  .description("Get task output")
+  .action(async (id: string) => {
+    const task = await api<Record<string, unknown>>(`/api/tasks/${id}`);
+    console.log(task.output ?? "(no output)");
+  });
+
+// ── diff ──
+program
+  .command("diff <id>")
+  .description("Get git diff for a completed task")
+  .action(async (id: string) => {
+    const result = await api<Record<string, unknown>>(`/api/tasks/${id}/diff`);
+    console.log(result.diff ?? "(no diff)");
+  });
+
+// ── cancel ──
+program
+  .command("cancel <id>")
+  .description("Cancel a pending task")
+  .action(async (id: string) => {
+    const result = await api(`/api/tasks/${id}`, { method: "DELETE" });
+    out(result, !!program.opts().json);
+  });
+
+// ── retry ──
+program
+  .command("retry <id>")
+  .description("Retry a failed task")
+  .action(async (id: string) => {
+    const result = await api(`/api/tasks/${id}/retry`, { method: "POST" });
+    out(result, !!program.opts().json);
+  });
+
+// ── workers ──
+program
+  .command("workers")
+  .alias("w")
+  .description("Show worker pool status")
+  .action(async () => {
+    const workers = await api<Array<Record<string, unknown>>>("/api/workers");
+    if (program.opts().json) {
+      console.log(JSON.stringify(workers, null, 2));
+    } else {
+      for (const w of workers) {
+        const status = w.busy ? "\x1b[36mbusy\x1b[0m" : "\x1b[32midle\x1b[0m";
+        const task = w.currentTask ? ` → ${w.currentTask}` : "";
+        console.log(`  ${String(w.name).padEnd(14)} ${status}${task}`);
+      }
+    }
+  });
+
+// ── stats ──
+program
+  .command("stats")
+  .description("Show queue stats and cost summary")
+  .action(async () => {
+    const stats = await api<Record<string, unknown>>("/api/stats");
+    if (program.opts().json) {
+      console.log(JSON.stringify(stats, null, 2));
+    } else {
+      const col = 20;
+      const by = stats.byStatus as Record<string, number> | undefined;
+      console.log(`  ${"Total tasks".padEnd(col)}${stats.total}`);
+      if (by) {
+        console.log(`  ${"Success".padEnd(col)}\x1b[32m${by.success ?? 0}\x1b[0m`);
+        console.log(`  ${"Failed".padEnd(col)}\x1b[31m${by.failed ?? 0}\x1b[0m`);
+        console.log(`  ${"Running".padEnd(col)}\x1b[36m${by.running ?? 0}\x1b[0m`);
+        console.log(`  ${"Pending".padEnd(col)}\x1b[33m${by.pending ?? 0}\x1b[0m`);
+        console.log(`  ${"Timeout".padEnd(col)}\x1b[35m${by.timeout ?? 0}\x1b[0m`);
+      }
+      console.log(`  ${"Total cost".padEnd(col)}$${Number(stats.totalCost ?? 0).toFixed(2)}`);
+      console.log(`  ${"Queue size".padEnd(col)}${stats.queueSize}`);
+      console.log(`  ${"Active workers".padEnd(col)}${stats.activeWorkers}`);
+    }
+  });
+
+// ── watch (SSE stream) ──
+program
+  .command("watch")
+  .description("Watch real-time task events (SSE)")
+  .action(async () => {
+    const url = `${program.opts().url ?? BASE_URL}/api/events`;
+    console.log(`Watching events at ${url} (Ctrl+C to stop)\n`);
+
+    const res = await fetch(url);
+    if (!res.body) {
+      console.error("No response body");
+      process.exit(1);
+    }
+    const decoder = new TextDecoder();
+    const reader = res.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const text = decoder.decode(value, { stream: true });
+      for (const line of text.split("\n")) {
+        if (line.startsWith("data: ")) {
+          const data = line.slice(6).trim();
+          if (!data) continue;
+          try {
+            const event = JSON.parse(data);
+            const ts = new Date().toLocaleTimeString();
+            const type = event.type ?? "unknown";
+            const taskId = event.taskId ?? "";
+            const extra = event.status ? ` [${statusColor(event.status)}]` : "";
+            console.log(`${ts}  ${type.padEnd(18)} ${taskId}${extra}`);
+          } catch {
+            // keep-alive ping or malformed
+          }
+        }
+      }
+    }
+  });
+
+// ── search ──
+program
+  .command("search <query>")
+  .description("Search tasks by keyword")
+  .action(async (query: string) => {
+    const tasks = await api<Array<Record<string, unknown>>>(`/api/tasks/search?q=${encodeURIComponent(query)}`);
+    if (program.opts().json) {
+      console.log(JSON.stringify(tasks, null, 2));
+    } else {
+      console.log(`${"ID".padEnd(10)} ${"STATUS".padEnd(10)} ${"COST".padEnd(8)} ${"TIME".padEnd(8)} PROMPT`);
+      console.log("─".repeat(80));
+      for (const t of tasks) printRow(t);
+      console.log(`\n${tasks.length} results`);
+    }
+  });
+
+program.parseAsync().catch((err: Error) => {
+  console.error(`\x1b[31mError:\x1b[0m ${err.message}`);
+  process.exit(1);
+});

--- a/v1/src/worktree-pool.ts
+++ b/v1/src/worktree-pool.ts
@@ -1,6 +1,6 @@
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, symlinkSync, lstatSync } from "node:fs";
 import path from "node:path";
 import type { WorkerInfo } from "./types.js";
 import { log } from "./logger.js";
@@ -33,7 +33,8 @@ export class WorktreePool {
     const wtDir = path.join(this.repoPath, ".worktrees");
     mkdirSync(wtDir, { recursive: true });
 
-    await this.git("checkout", "main").catch(() => {});
+    // Do NOT checkout main here — it changes the repo's working tree HEAD,
+    // which corrupts the repo when --repo points to the current directory.
 
     const worktreePromises = Array.from({ length: this.poolSize }, async (_, i) => {
       const name = `worker-${i}`;
@@ -153,9 +154,38 @@ export class WorktreePool {
     }
 
     try {
-      await this.gitIn(w.path, "clean", "-fdx");
+      // Exclude node_modules from clean — we symlink it for build verification
+      await this.gitIn(w.path, "clean", "-fdx", "-e", "node_modules", "-e", "v1/node_modules");
     } catch (err) {
       log("error", "[pool] clean failed", { worker: w.name, err: String(err) });
+    }
+
+    // Ensure node_modules symlinks exist so agents can run npx tsc
+    this.ensureNodeModulesSymlink(w.path);
+  }
+
+  /** Symlink node_modules from the main repo into the worktree so build tools work. */
+  private ensureNodeModulesSymlink(worktreePath: string): void {
+    const mainNM = path.join(this.repoPath, "v1", "node_modules");
+    const wtNM = path.join(worktreePath, "v1", "node_modules");
+
+    if (!existsSync(mainNM)) return;
+
+    const wtV1 = path.join(worktreePath, "v1");
+    if (!existsSync(wtV1)) mkdirSync(wtV1, { recursive: true });
+
+    try {
+      const stat = lstatSync(wtNM);
+      if (stat.isSymbolicLink()) return;
+    } catch {
+      // Does not exist — create it
+    }
+
+    try {
+      symlinkSync(mainNM, wtNM, "dir");
+      log("debug", "[pool] symlinked node_modules", { worktree: worktreePath });
+    } catch (err) {
+      log("warn", "[pool] failed to symlink node_modules", { worktree: worktreePath, err: String(err) });
     }
   }
 
@@ -166,20 +196,30 @@ export class WorktreePool {
 
     log("info", "[pool] merging branch", { branch: w.branch, target: "main" });
 
-    // Merge without checking out — stay on main
+    // Safe merge: update the main ref without touching HEAD or working tree.
+    // First try fast-forward via `git fetch . <branch>:main`.
+    // If that fails (non-ff), do a real merge in the worktree instead.
     try {
-      await this.git("merge", w.branch, "--no-edit");
+      await this.git("fetch", ".", `${w.branch}:main`);
     } catch {
-      // Collect conflicting file names before aborting
-      let conflictFiles: string[] = [];
+      // Non-fast-forward — merge in the worktree where it's safe
       try {
-        const { stdout } = await this.git("diff", "--name-only", "--diff-filter=U");
-        conflictFiles = stdout.trim().split("\n").filter(Boolean);
-      } catch {}
+        await this.gitIn(w.path, "checkout", "main");
+        await this.gitIn(w.path, "merge", w.branch, "--no-edit");
+        // Push the merged main back to the main repo ref
+        await this.git("fetch", w.path, "main:main");
+      } catch {
+        let conflictFiles: string[] = [];
+        try {
+          const { stdout } = await this.gitIn(w.path, "diff", "--name-only", "--diff-filter=U");
+          conflictFiles = stdout.trim().split("\n").filter(Boolean);
+        } catch {}
 
-      log("warn", "[pool] merge conflict, aborting", { branch: w.branch });
-      await this.git("merge", "--abort").catch(() => {});
-      return { merged: false, conflictFiles };
+        log("warn", "[pool] merge conflict, aborting", { branch: w.branch });
+        await this.gitIn(w.path, "merge", "--abort").catch(() => {});
+        await this.gitIn(w.path, "checkout", w.branch).catch(() => {});
+        return { merged: false, conflictFiles };
+      }
     }
 
     // Reset worktree to latest main


### PR DESCRIPTION
## Summary
- **cc-m CLI client**: Full-featured CLI for interacting with cc-manager server (submit, list, status, logs, diff, cancel, retry, workers, stats, watch, search, batch)
- **Critical self-hosting fix**: `git checkout main` in `init()` and `git merge` in `mergeToMain()` corrupted the main repo HEAD when `--repo .` pointed to self (caused `core.bare = true`, working tree loss)
- **Safe merge**: Uses `git fetch . <branch>:main` (ref-only update) instead of `git merge` which changes HEAD and working tree
- **Worktree node_modules**: Symlinks `v1/node_modules` from main repo into worktrees so agents can run `npx tsc`
- **Claude CLI fix**: Added `--verbose` flag required for `--output-format stream-json`

## Test plan
- [x] 71/71 tests pass (individual run)
- [x] tsc clean
- [x] `cc-m stats`, `cc-m workers`, `cc-m list` tested against running server
- [ ] Self-hosting round with fixed merge logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)