### PR TITLE
chore: add commit discipline rules + fix pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,10 @@ fi
 echo "pre-commit: type checking..."
 cd v1 && npx tsc --noEmit
 
+# Clear GIT_DIR/GIT_INDEX_FILE so tests that create temp git repos work correctly
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE
+
 echo "pre-commit: running tests..."
-node --import tsx --test src/__tests__/*.test.ts
+node --import tsx --test --test-concurrency=1 src/__tests__/*.test.ts
 
 echo "pre-commit: all checks passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ node dist/index.js --repo /path/to/repo --workers 5 --port 8080
 ```
 
 ```bash
-# Run tests (66 tests across 5 suites)
+# Run tests (217 tests across 5 suites)
 cd v1 && node --import tsx --test src/__tests__/*.test.ts
 ```
 
@@ -40,6 +40,13 @@ cd v1 && node --import tsx --test src/__tests__/*.test.ts
 - Core files: server.ts, scheduler.ts, store.ts, agent-runner.ts, worktree-pool.ts, index.ts, types.ts, logger.ts
 - Keep changes minimal and focused — one concern per change
 - Always `git add -A && git commit` after successful changes
+
+### Commit & PR Discipline (CRITICAL)
+- **One logical change per commit** — never bundle unrelated fixes. If fixing 3 bugs, that's 3 commits.
+- **Commit immediately** — after each change passes `npx tsc` + tests, commit before starting the next change.
+- **Small PRs** — each PR addresses one concern (one bug fix, one feature, one refactor). Split large work into multiple PRs.
+- **No mega commits** — if a commit touches 5+ files for different reasons, it's too big. Stop and split.
+- **Test with the fix** — each commit includes its own test additions, not batched at the end.
 
 ## Agent Flywheel Strategy
 The cc-manager improves itself by running agents against its own codebase.
@@ -144,6 +151,12 @@ pending → running → success (branch merged to main)
 - **GitHub**: `agent-next/cc-manager` (private)
 - **Version**: v0.1.0
 
+## Security Notes
+- **No authentication**: cc-manager has no auth. It is a local dev tool — do NOT expose to the public internet.
+- **CORS is open**: `cors()` middleware allows all origins. If deploying behind a reverse proxy, restrict at the proxy level.
+- **Webhook SSRF**: Webhook URLs are validated to block private/loopback IPs, but DNS rebinding is not prevented. Only use trusted webhook endpoints.
+- **Rate limiting**: Uses a static key (`"direct"`) — does not trust `x-forwarded-for`. If behind a reverse proxy, add `--trust-proxy` support.
+
 ## Known Gotchas
 - `getDailyStats()` returns `{total, success, cost, successRate}` — do NOT use `count` (old field name, causes silent breakage in dashboard + scheduler)
 - Dashboard `esc()` must escape single quotes (`&#39;`) for onclick handlers
@@ -151,3 +164,4 @@ pending → running → success (branch merged to main)
 - `POST /api/tasks` accepts `agent` field: `"claude"` (CLI), `"claude-sdk"` (Agent SDK), `"codex"`, or any CLI command string
 - `"claude-sdk"` uses programmatic `query()` API with structured events, AbortController, precise cost tracking
 - `"claude"` uses `claude -p --dangerously-skip-permissions --output-format stream-json` CLI spawning
+- Task IDs are 16-char hex (v0.1.0+). Store uses INSERT OR IGNORE + UPDATE to prevent collision overwrites.


### PR DESCRIPTION
## Summary
- Add **Commit & PR Discipline** section to project CLAUDE.md with rules for atomic commits, small PRs, and no mega commits
- Fix pre-commit hook: `unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE` so tests that create temp git repos don't accidentally commit to the main repo
- Serialize test suites with `--test-concurrency=1` for reliability
- Add **Security Notes** section documenting no-auth, open CORS, webhook SSRF, and rate limiting caveats
- Update test count from 66 to 217
- Add Task ID collision gotcha to Known Gotchas

## Test plan
- [x] Pre-commit hook passes on commit
- [ ] Verify tests pass in CI with `--test-concurrency=1`
- [ ] Confirm worktree-based tests no longer interfere with main repo git state

🤖 Generated with [Claude Code](https://claude.com/claude-code)