### PR TITLE
fix(cli): make --url flag work for all subcommands

### DIFF
--- a/v1/src/cli.ts
+++ b/v1/src/cli.ts
@@ -8,8 +8,12 @@ const BASE_URL = process.env.CC_MANAGER_URL ?? "http://localhost:8080";
 
 // ── Helpers ──
 
+function getBaseUrl(): string {
+  return program.opts().url ?? BASE_URL;
+}
+
 async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
-  const url = `${BASE_URL}${path}`;
+  const url = `${getBaseUrl()}${path}`;
   const res = await fetch(url, {
     ...init,
     headers: { "Content-Type": "application/json", ...init?.headers },


### PR DESCRIPTION
## Summary
- Add `getBaseUrl()` helper that reads `program.opts().url` dynamically at call time
- Replace static `BASE_URL` reference in `api()` with `getBaseUrl()` call
- Previously the `--url` flag was defined on the program but only used by the `watch` command; now all subcommands (`submit`, `status`, `tasks`, `workers`, `cancel`, `retry`) respect it

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [ ] Manual: `cc-m --url http://remote:8080 tasks` connects to custom URL
- [ ] Manual: `cc-m tasks` still defaults to `http://localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)