### PR TITLE
docs: add non-npm install and build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A multi-agent orchestrator that runs parallel coding agents in git worktrees. Su
 ## Prerequisites
 
 - **Node.js 20+**
+- A JavaScript package manager (**npm**, **pnpm**, or **yarn**)
 - **git**
 - At least one agent CLI installed:
   - **Claude Code** (`claude` CLI) — set `ANTHROPIC_API_KEY`
@@ -57,13 +58,30 @@ A multi-agent orchestrator that runs parallel coding agents in git worktrees. Su
 ## Installation
 
 ```bash
+# npm
 npm install -g cc-manager
+
+# pnpm
+pnpm add -g cc-manager
+
+# yarn
+yarn global add cc-manager
 ```
 
-Or run from source:
+Or run from source (no global install):
 
 ```bash
-cd v1 && npm install && npx tsc
+cd v1
+
+# npm
+npm install && npm run build
+
+# pnpm
+pnpm install && pnpm build
+
+# yarn
+yarn install && yarn build
+
 node dist/index.js --repo /path/to/repo
 ```
 


### PR DESCRIPTION
## What
- make prerequisites explicit: package manager can be `npm`, `pnpm`, or `yarn`
- add install alternatives for global install (`npm`/`pnpm`/`yarn`)
- add source-build alternatives (`npm`/`pnpm`/`yarn`)

## Why
Some environments do not have `npm` available. Docs should provide equivalent paths instead of blocking setup.

## Scope
- `README.md` only
