### PR TITLE
docs: improve Boris tagline and add X link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 [![CI](https://github.com/agent-next/cc-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/agent-next/cc-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> I need a Boris.
+> I need a Boris to manage my Claude Code.
+>
+> CC-Manager is that Boris: orchestrate parallel agents, enforce budgets, and auto-merge verified results.
+>
+> Boris on X: [@bcherny](https://x.com/bcherny)
 
 A multi-agent orchestrator that runs parallel coding agents in git worktrees. Supports Claude Agent SDK, Claude CLI, Codex CLI, and any terminal agent. Submit tasks via REST API, monitor in real-time via SSE, and agents auto-commit and merge to `main`.
 


### PR DESCRIPTION
## What
- upgrade the Boris promo line in README into a clearer product positioning block
- add direct Boris X link

## Scope
- `README.md`
