### PR TITLE
chore: fix pre-commit hook GIT_DIR leak

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,6 +10,8 @@ echo "pre-commit: type checking..."
 cd v1 && npx tsc --noEmit
 
 echo "pre-commit: running tests..."
-node --import tsx --test src/__tests__/*.test.ts
+# Clear GIT_DIR/GIT_INDEX_FILE so tests that create temp git repos work correctly
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE
+node --import tsx --test --test-concurrency=1 src/__tests__/*.test.ts
 
 echo "pre-commit: all checks passed"


### PR DESCRIPTION
## Summary
- Unset `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` before running tests in pre-commit hook
- Add `--test-concurrency=1` to prevent flaky parallel git operations

## Context
Worktree tests create temp git repos via `makeTempRepo()`. When run inside the pre-commit hook, leaked GIT env vars cause these temp repos to use the main repo's index, corrupting git state.

## Test plan
- [ ] Pre-commit hook passes on v1/ changes
- [ ] Worktree tests pass inside hook context

🤖 Generated with [Claude Code](https://claude.com/claude-code)