### PR TITLE
docs: add security notes + update test count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ node dist/index.js --repo /path/to/repo --workers 5 --port 8080
 ```
 
 ```bash
-# Run tests (66 tests across 5 suites)
+# Run tests (217 tests across 5 suites)
 cd v1 && node --import tsx --test src/__tests__/*.test.ts
 ```
 
@@ -144,6 +144,12 @@ pending → running → success (branch merged to main)
 - **GitHub**: `agent-next/cc-manager` (private)
 - **Version**: v0.1.0
 
+## Security Notes
+- **No authentication**: cc-manager has no auth. It is a local dev tool — do NOT expose to the public internet.
+- **CORS is open**: `cors()` middleware allows all origins. If deploying behind a reverse proxy, restrict at the proxy level.
+- **Webhook SSRF**: Webhook URLs are validated to block private/loopback IPs, but DNS rebinding is not prevented. Only use trusted webhook endpoints.
+- **Rate limiting**: Uses a static key (`"direct"`) — does not trust `x-forwarded-for`. If behind a reverse proxy, add `--trust-proxy` support.
+
 ## Known Gotchas
 - `getDailyStats()` returns `{total, success, cost, successRate}` — do NOT use `count` (old field name, causes silent breakage in dashboard + scheduler)
 - Dashboard `esc()` must escape single quotes (`&#39;`) for onclick handlers
@@ -151,3 +157,4 @@ pending → running → success (branch merged to main)
 - `POST /api/tasks` accepts `agent` field: `"claude"` (CLI), `"claude-sdk"` (Agent SDK), `"codex"`, or any CLI command string
 - `"claude-sdk"` uses programmatic `query()` API with structured events, AbortController, precise cost tracking
 - `"claude"` uses `claude -p --dangerously-skip-permissions --output-format stream-json` CLI spawning
+- Task IDs are 16-char hex (v0.1.0+). Store uses INSERT OR IGNORE + UPDATE to prevent collision overwrites.


### PR DESCRIPTION
## Summary
- Add security notes about auth/CORS (local dev tool warning)
- Update test count from 66 to 217
- Document task ID length change (8 → 16 chars)

## Test plan
- [ ] CLAUDE.md accurately reflects current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)