### PR TITLE
fix(cli): make --url flag work for all subcommands

### DIFF
--- a/v1/src/cli.ts
+++ b/v1/src/cli.ts
@@ -8,8 +8,12 @@ const BASE_URL = process.env.CC_MANAGER_URL ?? "http://localhost:8080";
 
 // ── Helpers ──
 
+function getBaseUrl(): string {
+  return program.opts().url ?? BASE_URL;
+}
+
 async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
-  const url = `${BASE_URL}${path}`;
+  const url = `${getBaseUrl()}${path}`;
   const res = await fetch(url, {
     ...init,
     headers: { "Content-Type": "application/json", ...init?.headers },


### PR DESCRIPTION
## Summary
- Extract `getBaseUrl()` to read `program.opts().url` instead of hardcoded `BASE_URL`
- All CLI subcommands now respect the `--url` flag

## Test plan
- [ ] `cc-m --url http://remote:8080 stats` connects to remote server

🤖 Generated with [Claude Code](https://claude.com/claude-code)