### PR TITLE
fix(worktree-pool): propagate reset failures

### DIFF
--- a/v1/src/__tests__/worktree-pool.test.ts
+++ b/v1/src/__tests__/worktree-pool.test.ts
@@ -149,3 +149,263 @@ describe("WorktreePool", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Health checks
+// ---------------------------------------------------------------------------
+
+describe("WorktreePool health", () => {
+  it("isHealthy returns true for valid worktree", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      const healthy = await pool.isHealthy("worker-0");
+      assert.strictEqual(healthy, true, "existing worktree should be healthy");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("isHealthy returns false for unknown worker name", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      const healthy = await pool.isHealthy("nonexistent-worker");
+      assert.strictEqual(healthy, false, "unknown worker should not be healthy");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale detection
+// ---------------------------------------------------------------------------
+
+describe("WorktreePool stale detection", () => {
+  it("isStale returns false for idle worker", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      const worker = pool.getWorker("worker-0");
+      assert.ok(worker, "worker-0 should exist");
+      assert.strictEqual(worker.busy, false, "worker should be idle");
+
+      const stale = pool.isStale(worker, 1);
+      assert.strictEqual(stale, false, "idle worker should never be stale");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("isStale returns true when busy beyond threshold", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      const worker = await pool.acquire();
+      assert.ok(worker !== null, "should acquire a worker");
+
+      // Wait just long enough so busySince is older than 1ms threshold
+      await new Promise((r) => setTimeout(r, 10));
+
+      const stale = pool.isStale(worker, 1);
+      assert.strictEqual(stale, true, "worker busy longer than threshold should be stale");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Force release
+// ---------------------------------------------------------------------------
+
+describe("WorktreePool force release", () => {
+  it("forceRelease marks worker as not busy", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 2);
+      await pool.init();
+
+      const worker = await pool.acquire();
+      assert.ok(worker !== null, "should acquire a worker");
+      assert.strictEqual(pool.busy, 1, "one worker should be busy before forceRelease");
+
+      await pool.forceRelease(worker.name);
+
+      assert.strictEqual(pool.busy, 0, "no workers should be busy after forceRelease");
+      assert.strictEqual(pool.available, 2, "all workers should be available after forceRelease");
+
+      // Verify the worker is re-acquirable after force release
+      const reacquired = await pool.acquire();
+      assert.ok(reacquired !== null, "worker should be acquirable after forceRelease");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("forceRelease handles unknown worker gracefully", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      // Should not throw for a non-existent worker name
+      await pool.forceRelease("nonexistent-worker");
+
+      // Pool state should remain unchanged
+      assert.strictEqual(pool.available, 1, "pool should still have its worker available");
+      assert.strictEqual(pool.busy, 0, "no workers should be busy");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker lookup
+// ---------------------------------------------------------------------------
+
+describe("WorktreePool lookup", () => {
+  it("getWorker finds worker by name", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 2);
+      await pool.init();
+
+      const worker = pool.getWorker("worker-0");
+      assert.ok(worker, "should find worker-0");
+      assert.strictEqual(worker.name, "worker-0");
+      assert.strictEqual(typeof worker.path, "string");
+      assert.strictEqual(typeof worker.branch, "string");
+
+      const worker1 = pool.getWorker("worker-1");
+      assert.ok(worker1, "should find worker-1");
+      assert.strictEqual(worker1.name, "worker-1");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("getWorker returns undefined for unknown name", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 1);
+      await pool.init();
+
+      const worker = pool.getWorker("does-not-exist");
+      assert.strictEqual(worker, undefined, "unknown name should return undefined");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("getWorkerByTask finds worker by current task ID", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 2);
+      await pool.init();
+
+      const worker = await pool.acquire();
+      assert.ok(worker !== null, "should acquire a worker");
+
+      // Simulate scheduler assigning a task to the worker
+      worker.currentTask = "task-abc-123";
+
+      const found = pool.getWorkerByTask("task-abc-123");
+      assert.ok(found, "should find worker by task ID");
+      assert.strictEqual(found.name, worker.name, "found worker should match acquired worker");
+      assert.strictEqual(found.currentTask, "task-abc-123");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("getWorkerByTask returns undefined for unknown task", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 2);
+      await pool.init();
+
+      // Acquire a worker with a different task
+      const worker = await pool.acquire();
+      assert.ok(worker !== null);
+      worker.currentTask = "task-known";
+
+      const found = pool.getWorkerByTask("task-unknown");
+      assert.strictEqual(found, undefined, "unknown task ID should return undefined");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker stats
+// ---------------------------------------------------------------------------
+
+describe("WorktreePool stats", () => {
+  it("getWorkerStats returns correct counts", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 3);
+      await pool.init();
+
+      // All idle initially
+      let stats = pool.getWorkerStats();
+      assert.strictEqual(stats.total, 3, "total should be 3");
+      assert.strictEqual(stats.busy, 0, "no workers busy initially");
+      assert.strictEqual(stats.available, 3, "all workers available initially");
+      assert.strictEqual(stats.stale, 0, "no stale workers initially");
+
+      // Acquire two workers
+      const w1 = await pool.acquire();
+      const w2 = await pool.acquire();
+      assert.ok(w1 !== null && w2 !== null);
+
+      stats = pool.getWorkerStats();
+      assert.strictEqual(stats.total, 3, "total should still be 3");
+      assert.strictEqual(stats.busy, 2, "two workers should be busy");
+      assert.strictEqual(stats.available, 1, "one worker should be available");
+      assert.strictEqual(stats.stale, 0, "recently acquired workers should not be stale");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("getWorkerStats reflects stale workers", async () => {
+    const { repoPath, cleanup } = await makeTempRepo();
+    try {
+      const pool = new WorktreePool(repoPath, 2);
+      await pool.init();
+
+      const worker = await pool.acquire();
+      assert.ok(worker !== null, "should acquire a worker");
+
+      // getWorkerStats uses a 5-minute threshold internally.
+      // The worker was just acquired, so it should not be stale.
+      let stats = pool.getWorkerStats();
+      assert.strictEqual(stats.stale, 0, "freshly acquired worker should not be stale");
+      assert.strictEqual(stats.busy, 1, "one worker should be busy");
+
+      // Verify that isStale with a very small threshold would detect it
+      await new Promise((r) => setTimeout(r, 10));
+      const stale = pool.isStale(worker, 1);
+      assert.strictEqual(stale, true, "worker should be stale with 1ms threshold");
+
+      // But getWorkerStats still reports 0 stale because it uses 5-minute threshold
+      stats = pool.getWorkerStats();
+      assert.strictEqual(stats.stale, 0, "worker should not be stale under 5-minute threshold");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/v1/src/worktree-pool.ts
+++ b/v1/src/worktree-pool.ts
@@ -85,8 +85,9 @@ export class WorktreePool {
           try {
             await this.resetWorktree(w);
           } catch (err) {
-            log("error", "[pool] acquire: failed to reset worktree", { worker: w.name, err: String(err) });
-            throw new Error(`Failed to reset worktree '${w.name}' during acquire: ${String(err)}`);
+            log("error", "[pool] acquire: failed to reset worktree, skipping", { worker: w.name, err: String(err) });
+            w.busy = false;
+            continue;
           }
           return w;
         }
@@ -136,28 +137,21 @@ export class WorktreePool {
   }
 
   private async resetWorktree(w: WorkerInfo): Promise<void> {
-    try {
-      await this.gitIn(w.path, "checkout", w.branch);
-    } catch (err) {
-      log("error", "[pool] checkout failed", { worker: w.name, err: String(err) });
-    }
+    await this.gitIn(w.path, "checkout", w.branch);
 
-    // Try origin/main first (picks up upstream changes), fall back to local main
+    // Try origin/main first (picks up upstream changes), fall back to local main.
+    // Let failures throw — a dirty worktree must not be reused.
     try {
       await this.gitIn(w.path, "reset", "--hard", "origin/main");
     } catch {
-      try {
-        await this.gitIn(w.path, "reset", "--hard", "main");
-      } catch (err) {
-        log("error", "[pool] reset failed", { worker: w.name, err: String(err) });
-      }
+      await this.gitIn(w.path, "reset", "--hard", "main");
     }
 
     try {
       // Exclude node_modules from clean — we symlink it for build verification
       await this.gitIn(w.path, "clean", "-fdx", "-e", "node_modules", "-e", "v1/node_modules");
     } catch (err) {
-      log("error", "[pool] clean failed", { worker: w.name, err: String(err) });
+      log("warn", "[pool] clean failed (non-fatal)", { worker: w.name, err: String(err) });
     }
 
     // Ensure node_modules symlinks exist so agents can run npx tsc


### PR DESCRIPTION
## Summary
- \`resetWorktree()\` was swallowing checkout/reset errors, allowing dirty worktrees to be reused
- Now let hard failures throw; keep \`clean -fdx\` as non-fatal warning
- \`acquire()\` catches and skips broken workers

## Test plan
- [ ] 83 tests pass (12 new worktree tests)
- [ ] Broken worktree is skipped, not reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)