### PR TITLE
docs: launch docs site and GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ A multi-agent orchestrator that runs parallel coding agents in git worktrees. Su
                                    └─────────────┘
 ```
 
+## Documentation
+
+- GitHub Pages: <https://agent-next.github.io/cc-manager/>
+- Docs home (in repo): [docs/index.html](docs/index.html)
+- Getting started: [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)
+- Operations guide: [docs/OPERATIONS.md](docs/OPERATIONS.md)
+- Configuration reference: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
+- API reference: [docs/API.md](docs/API.md)
+- Flywheel design: [docs/AGENT-FLYWHEEL-DESIGN.md](docs/AGENT-FLYWHEEL-DESIGN.md)
+
 ## Features
 
 - **Multi-agent support** — use Claude Code, OpenAI Codex, or any terminal CLI as workers

--- a/docs/AGENT-FLYWHEEL-DESIGN.md
+++ b/docs/AGENT-FLYWHEEL-DESIGN.md
@@ -1,441 +1,118 @@
-# Agent 飞轮 (Agent Flywheel) 扩展设计
+# Agent Flywheel Design
 
-> CC-Manager V1 → V2 演进路线：从线性调度到指数级自治
+CC-Manager's product direction is to move from simple queue execution to a self-improving orchestration loop.
 
-## 0. 核心洞察
+## 1. Core Thesis
 
-**底层能力在指数增长，编排系统必须跟上。**
+Model quality is improving quickly. The orchestration layer must keep pace by doing more than dispatching prompts.
 
-Claude Code 自身已经具备启动 Team Agents 的能力——每个 CC 实例不再只是"单兵"，而是一个能指挥子 agent 的"小队长"。这意味着 CC-Manager 的价值不在于管 10 个"士兵"，而在于管 10 个"将军"，每个将军再带自己的团队。
+The goal:
 
-```
-V0 (当前): Manager → 10 CC workers → 10 并行任务
-V1 (飞轮): Manager → 10 CC leads → 每个 lead 带 team → 30~100 并行能力
-V2 (自治): Manager → 动态 agent 树 → agent 自己决定何时分裂/合并
-```
+- turn one-shot task execution into a repeatable operating system
+- increase success rates through structured feedback
+- scale parallel execution without losing merge safety or budget control
 
-## 1. 飞轮模型
+## 2. Flywheel Loop
 
-### 1.1 什么是 Agent 飞轮
+The flywheel has four stages:
 
-传统的任务调度是线性的：人写 prompt → agent 执行 → 人检查 → 人写下一个 prompt。飞轮模型让这个循环自动旋转：
+1. Plan
+2. Execute
+3. Merge
+4. Learn
 
-```
-         ┌─────────────────────┐
-         │   任务分解 (Plan)    │
-         │  大任务 → 子任务列表  │
-         └──────────┬──────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   并行执行 (Execute) │
-         │  N agents × M subs  │
-         └──────────┬──────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   自动合并 (Merge)   │
-         │  git merge + 冲突   │
-         │  解决 + 集成验证     │
-         └──────────┬──────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   反馈学习 (Learn)   │
-         │  PROGRESS.md 更新    │
-         │  CLAUDE.md 进化      │
-         └──────────┬──────────┘
-                    │
-                    └──────────→ 回到 Plan（飞轮旋转）
+```text
+Plan -> Execute -> Merge -> Learn -> Plan
 ```
 
-关键：每一圈旋转，系统变得更聪明——CLAUDE.md 积累了项目知识，PROGRESS.md 记录了什么有效、什么无效，后续 agent 的成功率自然上升。
-
-### 1.2 从 20% 到 95% 的成功率曲线
-
-胡渊鸣的数据：初始派活成功率 ~20%，最终 ~95%。这不是魔法，是飞轮效应：
-
-| 阶段 | 成功率 | 飞轮状态 |
-|------|--------|---------|
-| 冷启动 | ~20% | CLAUDE.md 空，agent 不了解项目 |
-| 第一圈 | ~40% | 几个成功案例写入 PROGRESS.md |
-| 第二圈 | ~60% | CLAUDE.md 被手动/自动补充规则 |
-| 持续运转 | ~80% | 常见模式都有经验，只有新场景会失败 |
-| 稳态 | ~95% | CLAUDE.md 覆盖大部分情况，剩余 5% 是真正的 edge case |
-
-## 2. V1 架构：分层 Agent 树
-
-### 2.1 三层 Agent 模型
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    CC-Manager (编排层)                        │
-│  ┌─────────────────────────────────────────────────────┐    │
-│  │  RalphLoop (任务调度) + PlanEngine (任务分解)          │    │
-│  └──────────┬──────────────────────────────────────────┘    │
-│             │                                               │
-│  ┌──────────▼──────────────────────────────────────────┐    │
-│  │          Lead Agent Layer (10 worktrees)              │    │
-│  │                                                       │    │
-│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐                │    │
-│  │  │ Lead-0  │ │ Lead-1  │ │ Lead-N  │   ...           │    │
-│  │  │ Opus4.6 │ │ Opus4.6 │ │ Opus4.6 │                │    │
-│  │  │ (Plan+  │ │ (Plan+  │ │ (Plan+  │                │    │
-│  │  │  Code)  │ │  Code)  │ │  Code)  │                │    │
-│  │  └────┬────┘ └────┬────┘ └────┬────┘                │    │
-│  │       │           │           │                       │    │
-│  │  ┌────▼────┐ ┌────▼────┐ ┌────▼────┐                │    │
-│  │  │ Team    │ │ Team    │ │ Team    │   Sub-agents    │    │
-│  │  │Agents   │ │Agents   │ │Agents   │   由 CC 自身    │    │
-│  │  │(Sonnet) │ │(Sonnet) │ │(Sonnet) │   内置管理      │    │
-│  │  └─────────┘ └─────────┘ └─────────┘                │    │
-│  └─────────────────────────────────────────────────────┘    │
-│             │                                               │
-│  ┌──────────▼──────────────────────────────────────────┐    │
-│  │              Git Main (合并层)                         │    │
-│  └─────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────┘
-```
-
-核心变化：CC-Manager 不再直接控制每个 agent 的代码级行为，而是把复杂任务分配给 Lead Agent，由 Lead 利用 CC 内置的 team agent 能力自行组织执行。Manager 只关注 worktree 隔离、合并、资源和预算。
-
-### 2.2 PlanEngine — 任务自动分解
-
-V0 的任务是原子的（一个 prompt → 一个 agent）。V1 引入 PlanEngine，将大任务拆成可并行的子任务：
-
-```python
-class PlanEngine:
-    """将高层目标分解为可并行执行的子任务。"""
-
-    async def decompose(self, goal: str, codebase_context: str) -> list[SubTask]:
-        """
-        输入: "实现用户认证系统"
-        输出: [
-            SubTask("设计数据库schema", deps=[]),
-            SubTask("实现注册API", deps=["schema"]),
-            SubTask("实现登录API", deps=["schema"]),
-            SubTask("实现JWT中间件", deps=[]),
-            SubTask("编写单元测试", deps=["注册", "登录", "JWT"]),
-            SubTask("编写集成测试", deps=["所有API"]),
-        ]
-        """
-        # 使用 CC 自身做 planning (Opus 模型)
-        plan_prompt = self._build_plan_prompt(goal, codebase_context)
-        plan = await self.planner.run(plan_prompt)
-        return self._parse_plan(plan)
-
-    def build_dependency_graph(self, subtasks: list[SubTask]) -> DAG:
-        """构建依赖图，确定并行度。"""
-        ...
-
-    def schedule(self, dag: DAG, available_workers: int) -> Schedule:
-        """
-        根据依赖图和可用 workers 生成调度计划。
-        无依赖的任务可以并行，有依赖的按拓扑序执行。
-        """
-        ...
-```
-
-### 2.3 任务类型分级
-
-不是所有任务都需要 Lead + Team 的重型编排：
-
-| 类型 | 复杂度 | Agent 配置 | 示例 |
-|------|--------|-----------|------|
-| **Atomic** | 单文件修改 | 1 Sonnet agent | 修 typo、加日志 |
-| **Standard** | 多文件功能 | 1 Opus lead | 新增 API endpoint |
-| **Complex** | 跨模块系统 | 1 Opus lead + team | 实现认证系统 |
-| **Epic** | 架构级变更 | PlanEngine 分解 → 多 leads | 数据库迁移 + API 重构 |
-
-```python
-class TaskClassifier:
-    """根据 prompt 和代码库上下文自动分级。"""
-
-    async def classify(self, prompt: str, repo_stats: dict) -> TaskType:
-        # 分析因素:
-        # - prompt 涉及的文件数估计
-        # - 是否涉及新模块/跨模块
-        # - 是否有测试要求
-        # - 代码库规模
-        ...
-```
-
-## 3. 自动化反馈回路
-
-### 3.1 PROGRESS.md 自动维护
-
-每个任务完成后，系统自动更新经验库：
-
-```python
-class ProgressTracker:
-    """自动记录经验教训到 PROGRESS.md"""
-
-    async def record(self, task: Task, outcome: TaskOutcome):
-        entry = {
-            "task_type": task.classified_type,
-            "prompt_pattern": self._extract_pattern(task.prompt),
-            "success": outcome.success,
-            "duration": outcome.duration,
-            "cost": outcome.cost_usd,
-            "files_changed": outcome.files,
-            "error_pattern": outcome.error_category if not outcome.success else None,
-            "lesson": outcome.lesson,  # agent 自己总结的经验
-        }
-        await self._append_progress(entry)
-
-    async def get_relevant_lessons(self, new_task: Task) -> list[Lesson]:
-        """为新任务检索相关的历史经验。"""
-        # 基于 embedding 相似度匹配
-        ...
-```
-
-### 3.2 CLAUDE.md 自动进化
-
-当失败模式反复出现时，系统自动将经验提炼为规则：
-
-```python
-class RuleEvolver:
-    """从反复出现的模式中提炼规则。"""
-
-    async def check_and_evolve(self, progress: list[ProgressEntry]):
-        # 1. 检测反复失败的模式
-        failure_patterns = self._detect_recurring_failures(progress)
-
-        for pattern in failure_patterns:
-            if pattern.occurrence_count >= 3:
-                # 2. 使用 CC 生成新规则
-                rule = await self._generate_rule(pattern)
-                # 3. 追加到 CLAUDE.md
-                await self._append_rule(rule)
-                # 4. 记录规则来源
-                log.info(f"New rule added: {rule.summary} (from {pattern.count} failures)")
-```
-
-### 3.3 成本控制闭环
-
-```python
-class BudgetController:
-    """多层预算控制。"""
-
-    def __init__(self):
-        self.budget_per_task = 5.0      # 单任务上限
-        self.budget_per_hour = 50.0     # 每小时上限
-        self.budget_daily = 200.0       # 每日上限
-        self.budget_total = 1000.0      # 总预算
-
-    async def can_dispatch(self, task: Task) -> tuple[bool, str]:
-        """检查是否可以调度新任务。"""
-        if self._hourly_spend() > self.budget_per_hour:
-            return False, "Hourly budget exceeded"
-        if self._daily_spend() > self.budget_daily:
-            return False, "Daily budget exceeded"
-        return True, "OK"
-
-    def adjust_model(self, task: Task) -> str:
-        """根据剩余预算和任务复杂度选择模型。"""
-        remaining = self.budget_daily - self._daily_spend()
-        if remaining < 20:
-            return "haiku"  # 预算紧张用小模型
-        if task.type == TaskType.ATOMIC:
-            return "sonnet"  # 简单任务不需要 Opus
-        return "opus"        # 复杂任务用最强模型
-```
-
-## 4. V2 愿景：自治 Agent 网络
-
-### 4.1 Agent 自我复制
-
-当 CC 能启动 team agents 时，一个自然的延伸是：agent 自己判断何时需要分裂。
-
-```
-当前: Manager 决定并行度
-V2:   Agent 自己说 "这个任务太大了，我需要 3 个帮手"
-```
-
-```python
-class AdaptiveDispatcher:
-    """支持 agent 动态请求资源。"""
-
-    async def handle_resource_request(self, lead_id: str, request: ResourceRequest):
-        """Lead agent 请求更多 worktrees/sub-agents。"""
-        if request.type == "more_workers":
-            available = self.pool.available_count
-            granted = min(request.count, available, self.max_per_lead)
-            sub_worktrees = []
-            for _ in range(granted):
-                wt = await self.pool.acquire()
-                if wt:
-                    sub_worktrees.append(wt)
-            return sub_worktrees
-
-        if request.type == "upgrade_model":
-            if self.budget.can_afford_upgrade():
-                return {"model": "opus"}
-            return {"model": "sonnet", "reason": "budget constraint"}
-```
-
-### 4.2 合并冲突自动解决
-
-10+ agents 并行写代码，合并冲突不可避免。V2 引入自动化冲突解决：
-
-```python
-class ConflictResolver:
-    """Git 合并冲突自动解决。"""
-
-    async def resolve(self, worktree: str, target: str = "main") -> MergeResult:
-        result = await self._try_merge(worktree, target)
-
-        if result.has_conflicts:
-            # 策略 1: 简单冲突（不同文件修改同一区域）→ 自动选择
-            if result.conflict_type == "simple":
-                return await self._auto_resolve_simple(result)
-
-            # 策略 2: 语义冲突（逻辑不兼容）→ 启动新 agent 解决
-            if result.conflict_type == "semantic":
-                resolver_task = Task(
-                    prompt=self._build_resolve_prompt(result),
-                    timeout=120,
-                )
-                return await self.dispatcher.run(resolver_task, worktree)
-
-            # 策略 3: 严重冲突 → 人工介入
-            return MergeResult(success=False, needs_human=True,
-                              conflicts=result.conflicts)
-
-        return result
-```
-
-### 4.3 质量门控 (Quality Gate)
-
-飞轮不能只追求速度，还需要质量保证：
-
-```python
-class QualityGate:
-    """合并前自动质量检查。"""
-
-    async def check(self, worktree: str, task: Task) -> QualityReport:
-        checks = await asyncio.gather(
-            self._run_linter(worktree),
-            self._run_tests(worktree),
-            self._check_type_safety(worktree),
-            self._review_diff_size(worktree),
-        )
-
-        report = QualityReport(checks=checks)
-
-        if report.has_blockers:
-            # 给 agent 反馈，让它修复
-            fix_task = Task(
-                prompt=f"Fix the following issues:\n{report.blocker_summary}",
-                parent_id=task.id,
-            )
-            return report, fix_task
-
-        return report, None
-```
-
-## 5. 实现路线图
-
-### Phase 1: 强化基础 (V0 → V0.5) — 1~2 周
-
-当前 V0 已有 60 个测试全部通过。下一步：
-
-- [ ] 端到端集成测试（真实 CC 调用，非 mock）
-- [ ] WebSocket 实时推送压力测试
-- [ ] 10 worktree 并行合并的冲突处理
-- [ ] 预算控制和自动降级
-- [ ] 错误重试（指数退避 + 最大重试次数）
-
-### Phase 2: 飞轮 MVP (V1.0) — 2~4 周
-
-- [ ] PlanEngine: 大任务自动分解
-- [ ] TaskClassifier: 按复杂度分级
-- [ ] ProgressTracker: 自动记录经验
-- [ ] CLAUDE.md 自动追加规则
-- [ ] BudgetController: 多层预算控制
-- [ ] Web UI: 任务依赖图可视化
-
-### Phase 3: Team Agent 集成 (V1.5) — 4~6 周
-
-- [ ] Lead Agent 配置模板
-- [ ] CC team agent API 集成
-- [ ] AdaptiveDispatcher: 动态资源分配
-- [ ] Sub-worktree 管理（嵌套隔离）
-- [ ] 跨 team 合并策略
-
-### Phase 4: 自治网络 (V2.0) — 长期
-
-- [ ] ConflictResolver: 自动合并冲突解决
-- [ ] QualityGate: 合并前自动检查
-- [ ] RuleEvolver: CLAUDE.md 自动进化
-- [ ] Agent 间通信协议
-- [ ] 分布式 worktree pool（多机器）
-
-## 6. 关键度量
-
-飞轮是否真正转起来，看这些指标：
-
-| 指标 | V0 基线 | V1 目标 | V2 目标 |
-|------|---------|---------|---------|
-| 并行度 | 10 agents | 10 leads × 3 subs = 30 | 动态, 50~100 |
-| 任务成功率 | 手动验证 | >80% 自动 | >95% 自动 |
-| 人工干预频率 | 每任务 | 每 5 任务 | 每 20 任务 |
-| Commit 频率 | ~1/min | ~3/min | ~5/min |
-| 单日产出 (commits) | ~500 | ~1500 | ~3000 |
-| 平均成本/commit | ~$0.05 | ~$0.03 | ~$0.02 |
-| CLAUDE.md 规则数 | 手动 | 半自动增长 | 自动进化 |
-| 冲突解决 | 手动 | 半自动 | 全自动 |
-
-## 7. 设计原则
-
-1. **Agent Ready**: 每一层都先写测试再实现，确保 agent 可以安全接手
-2. **渐进复杂度**: 先让简单的转起来，再加复杂度——不要一步到 V2
-3. **预算即限速器**: 永远不能无限制烧钱，每层都有硬上限
-4. **人在回路**: V1/V2 的"自动"不是"无人"——关键决策仍需人类确认
-5. **可观测性优先**: 飞轮转得越快，可观测性越重要——每个 agent 的行为都要可追踪
-6. **失败是养料**: 每次失败都应该让系统变好，而不是简单重试
-
-## 8. 与现有系统的对接
-
-当前 `manager.py` 的改造点：
-
-```python
-# 现有接口保持不变
-class RalphLoop:
-    # 新增: PlanEngine 集成
-    def __init__(self, dispatcher, pool, on_event=None,
-                 plan_engine: Optional[PlanEngine] = None):
-        self.plan_engine = plan_engine or PlanEngine()
-
-    async def submit(self, task: Task) -> Task:
-        # 新增: 自动分类和分解
-        task.type = await self.classifier.classify(task.prompt)
-
-        if task.type == TaskType.EPIC:
-            subtasks = await self.plan_engine.decompose(task.prompt)
-            for st in subtasks:
-                st.parent_id = task.id
-                await self._enqueue(st)
-        else:
-            await self._enqueue(task)
-
-        return task
-```
-
-WebServer API 扩展：
-
-```
-GET  /api/stats          ← 现有
-POST /api/tasks          ← 现有
-GET  /api/tasks          ← 现有
-GET  /api/tasks/:id      ← 现有
-GET  /api/workers        ← 现有
-GET  /api/plan/:goal     ← 新增: 预览任务分解
-GET  /api/progress       ← 新增: 经验库查询
-GET  /api/rules          ← 新增: 当前规则列表
-POST /api/rules          ← 新增: 手动添加规则
-GET  /api/budget          ← 新增: 预算状态
-WS   /ws                 ← 现有
-```
-
----
-
-*文档版本: 2026-02-28 | 作者: CC-Manager Team*
-*基于 V0 (60 tests passing) 的实际运行经验编写*
+### Plan
+
+- classify task complexity
+- split larger requests into dependency-aware subtasks
+- choose model/agent profile from task type and budget state
+
+### Execute
+
+- dispatch work in isolated git worktrees
+- stream progress and collect structured outcomes
+- enforce timeout and budget limits at runtime
+
+### Merge
+
+- apply quality gates before integration
+- attach diff evidence and task metadata
+- merge successful branches, retain failed state for retry or analysis
+
+### Learn
+
+- extract patterns from failures and retries
+- append repeatable lessons to project guidance
+- improve prompts, guardrails, and routing rules over time
+
+## 3. Task Tiers
+
+CC-Manager should route tasks by complexity instead of using one fixed execution path.
+
+| Tier | Typical Scope | Routing Strategy |
+|---|---|---|
+| Atomic | single-file or low-risk edits | one worker, fast model |
+| Standard | multi-file feature work | one strong lead worker |
+| Complex | cross-module changes | lead + delegated subtasks |
+| Epic | architecture or migration work | plan engine + phased execution |
+
+## 4. Quality and Verification
+
+Throughput without trust is noise. The flywheel must enforce proof-first verification.
+
+Recommended gates before merge:
+
+- static checks and type checks
+- targeted tests for changed behavior
+- explicit acceptance criteria from the task prompt
+- metadata artifact: duration, tokens, cost, changed files
+
+## 5. Budget Intelligence
+
+Budget policy should operate at multiple levels:
+
+- per task
+- per hour/day
+- per run or release window
+
+Dynamic model routing can reduce spend:
+
+- use lightweight models for atomic tasks
+- reserve higher-cost models for complex work
+- degrade gracefully when budget thresholds are reached
+
+## 6. V1 to V2 Path
+
+### V1 (current focus)
+
+- stable parallel execution
+- reliable task API and event stream
+- deterministic merge behavior with retries
+
+### V1.5
+
+- task decomposition engine
+- conflict prediction and early warning
+- richer historical analytics
+
+### V2
+
+- adaptive agent trees with delegated subtasks
+- policy-driven auto-scaling based on queue pressure
+- continuously improved orchestration rules from observed outcomes
+
+## 7. Success Metrics
+
+To prove the flywheel works, track these metrics over time:
+
+- task success rate
+- mean time to completion
+- merge failure rate
+- cost per successful task
+- retry rate by task tier
+
+A healthy flywheel shows increasing success and decreasing manual intervention at a stable cost envelope.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,110 @@
+# Getting Started
+
+This guide gets `cc-manager` running locally in minutes.
+
+## 1. Prerequisites
+
+- Node.js 20+
+- `git`
+- One supported agent CLI:
+  - `claude` (Anthropic CLI)
+  - `codex` (OpenAI Codex CLI)
+  - any custom command that accepts a prompt
+- Anthropic API key for Claude-based runs:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+## 2. Install
+
+Choose one package manager:
+
+```bash
+# npm
+npm install -g cc-manager
+
+# pnpm
+pnpm add -g cc-manager
+
+# yarn
+yarn global add cc-manager
+```
+
+If `npm` is unavailable in your environment, use `pnpm` or `yarn`.
+
+## 3. Run the Server
+
+```bash
+cc-manager --repo /path/to/your/repo
+```
+
+Important flags:
+
+- `--workers <n>`: parallel worker count (1-20)
+- `--port <n>`: server port (default `8080`)
+- `--agent <cmd>`: default agent (`claude`, `codex`, or custom command)
+- `--budget <usd>`: per-task spending guardrail
+- `--total-budget <usd>`: total spending guardrail across all tasks
+
+Example:
+
+```bash
+cc-manager \
+  --repo /path/to/your/repo \
+  --workers 6 \
+  --agent codex \
+  --budget 3 \
+  --total-budget 50
+```
+
+## 4. Submit Your First Task
+
+```bash
+curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Add input validation to the login form"}'
+```
+
+## 5. Watch Real-Time Events
+
+```bash
+curl -N http://localhost:8080/api/events
+```
+
+Common event types:
+
+- `task_queued`
+- `task_started`
+- `task_progress`
+- `task_final`
+
+## 6. Verify Results
+
+```bash
+# List recent tasks
+curl http://localhost:8080/api/tasks
+
+# Task details
+curl http://localhost:8080/api/tasks/<task-id>
+
+# Patch for completed task
+curl http://localhost:8080/api/tasks/<task-id>/diff
+```
+
+## 7. Run from Source (Optional)
+
+```bash
+git clone https://github.com/agent-next/cc-manager.git
+cd cc-manager/v1
+npm install
+npm run build
+node dist/index.js --repo /path/to/your/repo
+```
+
+## Next Documents
+
+- [Configuration Reference](./CONFIGURATION.md)
+- [API Reference](./API.md)
+- [Operations Guide](./OPERATIONS.md)
+- [Agent Flywheel Design](./AGENT-FLYWHEEL-DESIGN.md)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,157 @@
+# Operations Guide
+
+Operational runbook for `cc-manager` in shared or production environments.
+
+## Runtime Baseline
+
+Recommended baseline:
+
+- Node.js 22 LTS
+- 4-10 workers for general workloads
+- dedicated repo clone per environment
+- persistent storage for `.cc-manager.db`
+
+Start command example:
+
+```bash
+cc-manager \
+  --repo /srv/repos/target-repo \
+  --workers 8 \
+  --port 8080 \
+  --budget 3 \
+  --total-budget 150
+```
+
+## Service Management
+
+Example `systemd` unit (`/etc/systemd/system/cc-manager.service`):
+
+```ini
+[Unit]
+Description=CC-Manager
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/cc-manager/v1
+Environment=ANTHROPIC_API_KEY=sk-ant-...
+ExecStart=/usr/local/bin/cc-manager --repo /srv/repos/target-repo --workers 8 --port 8080
+Restart=always
+RestartSec=3
+User=ccmanager
+Group=ccmanager
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cc-manager
+sudo systemctl start cc-manager
+sudo systemctl status cc-manager
+```
+
+## Upgrade Procedure
+
+1. Pull latest code.
+2. Install dependencies in `v1/`.
+3. Build TypeScript output.
+4. Restart service.
+5. Run health and smoke checks.
+
+```bash
+git pull
+cd v1
+npm ci
+npm run build
+sudo systemctl restart cc-manager
+curl http://localhost:8080/api/health
+```
+
+## Backup and Recovery
+
+`cc-manager` stores task state in SQLite files at repository root:
+
+- `.cc-manager.db`
+- `.cc-manager.db-shm`
+- `.cc-manager.db-wal`
+
+Daily backup recommendation:
+
+```bash
+tar -czf cc-manager-backup-$(date +%F).tgz \
+  .cc-manager.db .cc-manager.db-shm .cc-manager.db-wal
+```
+
+Recovery:
+
+1. Stop the service.
+2. Restore database files.
+3. Start the service.
+4. Verify `/api/health` and `/api/stats`.
+
+## Monitoring Checklist
+
+- `GET /api/health`: liveness and worker summary
+- `GET /api/stats`: queue depth, active workers, budget state
+- `GET /api/tasks/errors`: recent failures
+- `GET /api/workers`: worker saturation
+
+Suggested alerts:
+
+- queue depth above expected threshold for 10+ minutes
+- repeated task failures above baseline
+- total budget near hard cap
+- no successful tasks in a rolling time window
+
+## Troubleshooting
+
+### Agent command not found
+
+Symptom: tasks fail immediately with command execution errors.
+
+Actions:
+
+- confirm CLI is installed (`claude --version`, `codex --version`)
+- confirm binary is in service `PATH`
+- set explicit `--agent` command
+
+### Tasks time out frequently
+
+Actions:
+
+- increase `--timeout`
+- reduce `--workers` if host is saturated
+- split large prompts into smaller tasks
+
+### Merge conflicts increase with load
+
+Actions:
+
+- reduce parallelism for high-overlap code areas
+- use tags to segment queue by subsystem
+- retry failed tasks with narrower prompts
+
+### Budget exhausted too quickly
+
+Actions:
+
+- lower per-task `--budget`
+- set `--total-budget` to enforce global limits
+- move lower-priority work to off-peak windows
+
+## Security Notes
+
+- keep API keys in environment variables or a secret manager
+- avoid embedding secrets in task prompts
+- restrict network exposure of the server port
+- route through TLS and auth at an ingress or proxy layer
+
+## Related Docs
+
+- [Getting Started](./GETTING_STARTED.md)
+- [Configuration Reference](./CONFIGURATION.md)
+- [API Reference](./API.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CC-Manager Docs</title>
+    <meta
+      name="description"
+      content="CC-Manager documentation: multi-agent orchestration, budget controls, and merge-safe automation for engineering teams."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./site.css" />
+  </head>
+  <body>
+    <div class="site-backdrop" aria-hidden="true"></div>
+
+    <header class="site-header">
+      <a class="brand" href="./">CC-Manager</a>
+      <nav aria-label="Primary">
+        <a href="#quickstart">Quickstart</a>
+        <a href="#docs">Docs</a>
+        <a href="https://github.com/agent-next/cc-manager" target="_blank" rel="noreferrer">GitHub</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero reveal">
+        <p class="eyebrow">agent-next / cc-manager</p>
+        <h1>I need a Boris for Claude Code.</h1>
+        <p class="hero-copy">
+          CC-Manager is that Boris: orchestrate parallel coding agents, control spend with explicit guardrails,
+          and merge only verified outcomes back to <code>main</code>.
+        </p>
+
+        <div class="cta-row">
+          <a class="btn primary" href="#quickstart">Start in 3 Minutes</a>
+          <a class="btn ghost" href="https://x.com/bcherny" target="_blank" rel="noreferrer">Boris on X</a>
+        </div>
+
+        <ul class="signal-grid" aria-label="Key capabilities">
+          <li>
+            <strong>Parallel Execution</strong>
+            <span>Isolated git worktrees with up to 20 active workers.</span>
+          </li>
+          <li>
+            <strong>Proof-First Delivery</strong>
+            <span>Task output, diffs, and status streamed in real time.</span>
+          </li>
+          <li>
+            <strong>Repo Operability</strong>
+            <span>Consistent API surface, budgets, retries, and audit trail.</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="quickstart" class="card reveal">
+        <h2>Quickstart</h2>
+        <p>Pick one install path, then boot the API server and submit your first task.</p>
+
+        <div class="code-grid">
+          <article>
+            <h3>Install</h3>
+            <pre><code># npm
+npm install -g cc-manager
+
+# pnpm
+pnpm add -g cc-manager
+
+# yarn
+yarn global add cc-manager</code></pre>
+          </article>
+
+          <article>
+            <h3>Run</h3>
+            <pre><code>export ANTHROPIC_API_KEY="sk-ant-..."
+
+cc-manager --repo /path/to/your/repo --workers 6</code></pre>
+          </article>
+
+          <article>
+            <h3>Submit a task</h3>
+            <pre><code>curl -X POST http://localhost:8080/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Add input validation to signup form"}'</code></pre>
+          </article>
+        </div>
+      </section>
+
+      <section id="docs" class="card reveal">
+        <h2>Documentation</h2>
+        <div class="docs-grid">
+          <a href="./GETTING_STARTED.md">
+            <h3>Getting Started</h3>
+            <p>Setup, first run, CLI usage, and first API calls.</p>
+          </a>
+          <a href="./OPERATIONS.md">
+            <h3>Operations Guide</h3>
+            <p>Production runbook, upgrades, backups, and troubleshooting.</p>
+          </a>
+          <a href="./CONFIGURATION.md">
+            <h3>Configuration Reference</h3>
+            <p>All flags, env vars, and validated defaults.</p>
+          </a>
+          <a href="./API.md">
+            <h3>API Reference</h3>
+            <p>Task, monitoring, and evolution endpoints with examples.</p>
+          </a>
+          <a href="./AGENT-FLYWHEEL-DESIGN.md">
+            <h3>Agent Flywheel Design</h3>
+            <p>Roadmap from V1 orchestration to autonomous agent trees.</p>
+          </a>
+          <a href="https://github.com/agent-next/cc-manager" target="_blank" rel="noreferrer">
+            <h3>Repository</h3>
+            <p>Source code, issues, releases, and contribution workflow.</p>
+          </a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>CC-Manager by agent-next.</p>
+    </footer>
+
+    <script>
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) entry.target.classList.add("in");
+          });
+        },
+        { threshold: 0.1 }
+      );
+
+      document.querySelectorAll(".reveal").forEach((el) => observer.observe(el));
+    </script>
+  </body>
+</html>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,0 +1,300 @@
+:root {
+  --bg: #f0efe8;
+  --bg-warm: #ddd8c8;
+  --text: #10151d;
+  --muted: #4b5566;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-strong: #ffffff;
+  --line: rgba(16, 21, 29, 0.12);
+  --accent: #ba3a1b;
+  --accent-2: #1f5c4d;
+  --shadow: 0 18px 50px rgba(16, 21, 29, 0.11);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 12% 8%, #fff7d7, transparent 42%),
+    radial-gradient(circle at 89% 4%, #e2f2ec, transparent 45%),
+    linear-gradient(165deg, var(--bg) 0%, var(--bg-warm) 100%);
+  line-height: 1.45;
+}
+
+.site-backdrop {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(16, 21, 29, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 21, 29, 0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.4), transparent 80%);
+  z-index: -1;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem max(1.25rem, 4vw);
+  background: rgba(240, 239, 232, 0.86);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.site-header a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.site-header nav a:hover {
+  color: var(--accent);
+}
+
+.brand {
+  font-family: "IBM Plex Mono", monospace;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+main {
+  max-width: 1050px;
+  margin: 0 auto;
+  padding: 3.5rem max(1.25rem, 4vw) 4.5rem;
+}
+
+.hero h1 {
+  margin: 0.4rem 0 0;
+  font-size: clamp(2.1rem, 6vw, 4.35rem);
+  line-height: 0.95;
+  max-width: 10ch;
+}
+
+.eyebrow {
+  margin: 0;
+  font-family: "IBM Plex Mono", monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+.hero-copy {
+  max-width: 62ch;
+  margin: 1.1rem 0 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+}
+
+code,
+pre {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+code {
+  background: rgba(31, 92, 77, 0.09);
+  padding: 0.1rem 0.28rem;
+  border-radius: 0.35rem;
+}
+
+.cta-row {
+  margin-top: 1.45rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.62rem 1rem;
+  text-decoration: none;
+  font-weight: 600;
+  border: 1px solid var(--line);
+  transition: transform 130ms ease, box-shadow 130ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(16, 21, 29, 0.12);
+}
+
+.btn.primary {
+  background: var(--text);
+  color: #fff;
+  border-color: transparent;
+}
+
+.btn.ghost {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.signal-grid {
+  margin: 2rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.signal-grid li {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.signal-grid span {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.card {
+  margin-top: 1.6rem;
+  border: 1px solid var(--line);
+  border-radius: 1.1rem;
+  padding: 1.3rem;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 3vw, 1.8rem);
+}
+
+.card > p {
+  margin-top: 0.65rem;
+  color: var(--muted);
+}
+
+.code-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.code-grid article {
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  overflow: hidden;
+  background: var(--surface-strong);
+}
+
+.code-grid h3 {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.96rem;
+}
+
+pre {
+  margin: 0;
+  padding: 0.85rem;
+  overflow: auto;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.docs-grid {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.docs-grid a {
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid var(--line);
+  border-radius: 0.85rem;
+  padding: 0.85rem;
+  background: var(--surface-strong);
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.docs-grid a:hover {
+  border-color: rgba(186, 58, 27, 0.48);
+  transform: translateY(-2px);
+}
+
+.docs-grid h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.docs-grid p {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+  font-size: 0.93rem;
+}
+
+.site-footer {
+  padding: 0 1.25rem 2.2rem;
+  text-align: center;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 500ms ease, transform 500ms ease;
+}
+
+.reveal.in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 980px) {
+  .signal-grid,
+  .code-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.55rem;
+  }
+
+  .signal-grid,
+  .code-grid,
+  .docs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  main {
+    padding-top: 2.6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a public docs landing page under `docs/index.html` with dedicated styling
- add `docs/GETTING_STARTED.md` and `docs/OPERATIONS.md` for practical setup and runbook guidance
- add `.github/workflows/pages.yml` to deploy `docs/` on pushes to `main`
- update README docs links and rewrite flywheel design doc to English-only

## Validation
- docs/content review
- workflow YAML sanity check
