### PR TITLE
ci: enable Pages in deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- configure `actions/configure-pages` with `enablement: true`
- allows first-time Pages setup to succeed instead of failing with repository Pages not found

## Validation
- reviewed failure logs from run `22527055672`
