### PR TITLE
ci: remove Pages auto-enable now that site exists

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- remove `enablement: true` from `actions/configure-pages`
- keep workflow in standard mode now that Pages is already enabled at repo level

## Context
- Pages was manually enabled with `gh api -X POST repos/agent-next/cc-manager/pages -f build_type=workflow`
- this avoids `Resource not accessible by integration` errors in Actions
